### PR TITLE
Add !github lockall command

### DIFF
--- a/commands/command_github.go
+++ b/commands/command_github.go
@@ -110,20 +110,20 @@ func lockAllCommand(ctx *discord.CommandContext) error {
 	case 0:
 		msg = "Locked nothing."
 	case 1:
-		msg = fmt.Sprintf("Locked %s in repository **https://github.com/%s/%s**.", readable, github.Organization, repository)
+		msg = fmt.Sprintf("Closed and locked %s in repository **https://github.com/%s/%s**.", readable, github.Organization, repository)
 	default:
-		msg = fmt.Sprintf("Locked **%d** issues/PRs in repository **https://github.com/%s/%s**: %s.", len(lockedIssues), github.Organization, repository, readable)
+		msg = fmt.Sprintf("Closed and locked **%d** issues/PRs in repository **https://github.com/%s/%s**: %s.", len(lockedIssues), github.Organization, repository, readable)
 	}
 
 	if err == nil {
 		ctx.SendMessageWithAudit(
 			msg,
-			fmt.Sprintf("locked all issues/PRs from **%s** in the **%s/%s** repository with reason **%s**.\n\nLocked %s.", user, github.Organization, repository, reason, readable),
+			fmt.Sprintf("closed and locked all issues/PRs from **%s** in the **%s/%s** repository with reason **%s**.\n\nLocked %s.", user, github.Organization, repository, reason, readable),
 		)
 	} else {
 		ctx.SendMessageWithAudit(
 			msg,
-			fmt.Sprintf("locked all issues/PRs from **%s** in the **%s/%s** repository with reason **%s** (errors occured).\n\nLocked %s.", user, github.Organization, repository, reason, readable),
+			fmt.Sprintf("closed and locked all issues/PRs from **%s** in the **%s/%s** repository with reason **%s** (errors occured).\n\nLocked %s.", user, github.Organization, repository, reason, readable),
 		)
 	}
 

--- a/commands/command_github.go
+++ b/commands/command_github.go
@@ -2,32 +2,31 @@ package commands
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/FabricMC/fabric-discord-bot/discord"
 	"github.com/FabricMC/fabric-discord-bot/github"
 )
 
 func GithubCommand(ctx *discord.CommandContext) error {
-	if len(ctx.Content) != 2 {
+	if len(ctx.Content) < 2 {
 		err := ctx.SendMessage("Invalid arguments")
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	}
 
 	//TODO make a whole message system for this stuff, for now this will do
-	subCommand := ctx.Content[0]
-	if subCommand == "ban" || subCommand == "block" {
+	switch ctx.Content[0] {
+	case "ban", "block":
 		return banCommand(ctx)
-	} else if subCommand == "unban" || subCommand == "unblock" {
+	case "unban", "unblock":
 		return unbanCommand(ctx)
-	} else {
+	case "lockall":
+		return lockAllCommand(ctx)
+	default:
 		err := ctx.SendMessage("Sub command not found")
-		if err != nil {
-			return err
-		}
+		return err
 	}
-	return nil
 }
 
 func banCommand(ctx *discord.CommandContext) error {
@@ -73,4 +72,72 @@ func unbanCommand(ctx *discord.CommandContext) error {
 	}
 
 	return nil
+}
+
+func lockAllCommand(ctx *discord.CommandContext) error {
+	if len(ctx.Content) < 4 {
+		err := ctx.SendMessage("Invalid arguments. Usage: `github lockall <repository> <user> <reason>`")
+		return err
+	}
+	repository := ctx.Content[1]
+	user := ctx.Content[2]
+	reason := ctx.Content[3]
+	// blegh
+	if reason == "too" && ctx.Content[4] == "heated" {
+		reason = "too heated"
+	}
+
+	if !isValidLockReason(reason) {
+		err := ctx.SendMessage("Invalid lock reason. Valid reasons: `spam`, `off-topic`, `too heated`, `resolved`")
+		return err
+	}
+
+	lockedIssues, err := github.LockAll(github.Organization, repository, user, reason)
+
+	var builder strings.Builder
+	builder.WriteRune('#')
+	builder.WriteString(strconv.FormatInt(lockedIssues[0], 10))
+
+	for _, i := range lockedIssues[1:] {
+		builder.WriteString(", ")
+		builder.WriteRune('#')
+		builder.WriteString(strconv.FormatInt(i, 10))
+	}
+	readable := builder.String()
+
+	var msg string
+	switch len(lockedIssues) {
+	case 0:
+		msg = "Locked nothing."
+	case 1:
+		msg = fmt.Sprintf("Locked %s in repository **https://github.com/%s/%s**.", readable, github.Organization, repository)
+	default:
+		msg = fmt.Sprintf("Locked **%d** issues/PRs in repository **https://github.com/%s/%s**: %s.", len(lockedIssues), github.Organization, repository, readable)
+	}
+
+	if err == nil {
+		ctx.SendMessageWithAudit(
+			msg,
+			fmt.Sprintf("locked all issues/PRs from **%s** in the **%s/%s** repository with reason **%s**.\n\nLocked %s.", user, github.Organization, repository, reason, readable),
+		)
+	} else {
+		ctx.SendMessageWithAudit(
+			msg,
+			fmt.Sprintf("locked all issues/PRs from **%s** in the **%s/%s** repository with reason **%s** (errors occured).\n\nLocked %s.", user, github.Organization, repository, reason, readable),
+		)
+	}
+
+	return err
+}
+
+func isValidLockReason(reason string) bool {
+	switch reason {
+	case "off-topic",
+		"too heated",
+		"resolved",
+		"spam":
+		return true
+	default:
+		return false
+	}
 }

--- a/commands/command_github.go
+++ b/commands/command_github.go
@@ -75,16 +75,29 @@ func unbanCommand(ctx *discord.CommandContext) error {
 }
 
 func lockAllCommand(ctx *discord.CommandContext) error {
-	if len(ctx.Content) < 4 {
-		err := ctx.SendMessage("Invalid arguments. Usage: `github lockall <repository> <user> <reason>`")
+	if len(ctx.Content) < 3 {
+		err := ctx.SendMessage("Invalid arguments. Usage: `github lockall <repository> <user> [reason]`. If no reason is given, the default is `spam`")
 		return err
 	}
 	repository := ctx.Content[1]
 	user := ctx.Content[2]
-	reason := ctx.Content[3]
-	// blegh
-	if reason == "too" && ctx.Content[4] == "heated" {
-		reason = "too heated"
+	var reason string
+	switch len(ctx.Content) {
+	case 3:
+		{
+			reason = "spam"
+		}
+	case 4:
+		{
+			reason = ctx.Content[3]
+		}
+	default:
+		{
+			// blegh
+			if ctx.Content[3] == "too" && ctx.Content[4] == "heated" {
+				reason = "too heated"
+			}
+		}
 	}
 
 	if !isValidLockReason(reason) {


### PR DESCRIPTION
Locks all of a user's issues (and PRs, because those are actually just issues with a flag) on a specific repository with the given reason. If it errors halfway through it stops and returns what it did successfully lock.
I don't have an org I can lock people on for testing so I can't guarantee the api parts work (I tested by stubbing out the function). But hey, it compiles!

Didn't end up refactoring the command system, so some parts are not so nice.

One small part of #3 
![](https://cdn.discordapp.com/attachments/566418023372816394/736245555184926864/unknown.png)