### PR TITLE
Explicitly ignore config files so people don't leak their tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 
 # Source code
 !/src
+/src/main/resources/config.toml
 !/Tags
 
 # Ignore Gradle project-specific cache directory and build output directory


### PR DESCRIPTION
This is so I can test in IDE without any worries