### PR TITLE
Fix only digit queries not working

### DIFF
--- a/src/main/kotlin/net/fabricmc/bot/extensions/mappings/MappingsManager.kt
+++ b/src/main/kotlin/net/fabricmc/bot/extensions/mappings/MappingsManager.kt
@@ -26,7 +26,7 @@ const val NS_INTERMEDIARY = "intermediary"
 /** Namespace for yarn names. **/
 const val NS_NAMED = "named"
 
-private val ONLY_DIGITS = """[\d]""".toRegex()
+private val ONLY_DIGITS = """[\d]+""".toRegex()
 
 private val logger = KotlinLogging.logger {}
 


### PR DESCRIPTION
Here is an example of what I mean
![image](https://user-images.githubusercontent.com/47987888/107681258-987d6a80-6c7d-11eb-8ef5-c8cdceffebd5.png)

What the regex was doing was "match one digit", and it would match each digit by separate, so 1234 would match as `'1', '2', '3', '4'` instead of `'1234'`. You can check this by adding a `^` and a `$` to the start and end of the regex respectively.
Examples from regexr.com:
![image](https://user-images.githubusercontent.com/47987888/107682293-e8a8fc80-6c7e-11eb-867f-65cf67b57d42.png) 
![image](https://user-images.githubusercontent.com/47987888/107682343-fb233600-6c7e-11eb-8fd9-53aaa93b4fc7.png)


By adding the `+` at the end of the regex, what the regex does now is "match one or more of the preceding pattern".
![image](https://user-images.githubusercontent.com/47987888/107682415-12622380-6c7f-11eb-9def-7e464b7d15a6.png)
 ![image](https://user-images.githubusercontent.com/47987888/107682373-070ef800-6c7f-11eb-969c-26cb1590d952.png)
